### PR TITLE
Redeem handler v2 for onchain rates

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,6 +57,9 @@ jobs:
         run: yarn hardhat compile --force
 
       - name: Tests
+        timeout-minutes: 2
+        env:
+          MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
         run: yarn hardhat test --no-compile
 
       - name: Linters & Formatters

--- a/contracts/RedeemHandlerV2.sol
+++ b/contracts/RedeemHandlerV2.sol
@@ -176,8 +176,12 @@ contract RedeemHandlerV2 is AccessControl, EIP712, ReentrancyGuard, IRedeemHandl
         (int256 price, uint256 updatedAt) = getCollateralPrice(order.collateralAddress);
         emit OracleDataUsed(order.collateralAddress, price, updatedAt);
 
-        // Verify that the calculated amount matches the order (with some tolerance for precision)
         if (order.collateralAmount == 0) revert ZeroAmount();
+
+        // Validate that order.collateralAmount is not more advantageous than calculated amount
+        if (order.collateralAmount > calculatedCollateralAmount) {
+            revert InvalidCollateralAmount(order.collateralAmount, calculatedCollateralAmount);
+        }
 
         currentBlockRedeemAmount += order.usnAmount;
         usedNonces[order.user][order.nonce] = true;
@@ -414,7 +418,7 @@ contract RedeemHandlerV2 is AccessControl, EIP712, ReentrancyGuard, IRedeemHandl
         emit WhitelistedUserRemoved(user);
     }
 
-    function isWhitelisted(address user) public view returns (bool) {
+    function isWhitelisted(address user) public view override returns (bool) {
         return _whitelistedUsers[user];
     }
 }

--- a/contracts/RedeemHandlerV2.sol
+++ b/contracts/RedeemHandlerV2.sol
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import "./interfaces/IRedeemHandlerV2.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/interfaces/IERC1271.sol";
+
+// Chainlink AggregatorV3Interface
+interface AggregatorV3Interface {
+    function decimals() external view returns (uint8);
+
+    function description() external view returns (string memory);
+
+    function version() external view returns (uint256);
+
+    function getRoundData(
+        uint80 _roundId
+    )
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}
+
+contract RedeemHandlerV2 is AccessControl, EIP712, ReentrancyGuard, IRedeemHandlerV2 {
+    using SafeERC20 for IERC20;
+
+    // Remove duplicate struct definition
+    // Structs are inherited from the interface
+
+    // Constants
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+    bytes32 public constant ACCOUNTANT_ROLE = keccak256("ACCOUNTANT_ROLE");
+    bytes32 private constant REDEEM_TYPEHASH =
+        keccak256(
+            "RedeemOrder(string message,address user,address collateralAddress,uint256 collateralAmount,uint256 usnAmount,uint256 expiry,uint256 nonce)"
+        );
+
+    // Oracle configuration
+    uint256 public constant ORACLE_STALENESS_THRESHOLD = 86400; // max time between oracle updates in seconds
+    uint256 public constant USD_DECIMALS = 8; // Standard USD decimals for Chainlink
+    uint256 public constant MAX_PEG_PERCENTAGE = 10000; // 100% in basis points (10000 = 100%)
+
+    // State variables
+    ERC20Burnable public immutable usnToken;
+    address public treasury; // Single treasury address that holds all collaterals
+    mapping(address => bool) private _redeemableCollaterals;
+    mapping(address => address) public collateralOracles; // collateral => oracle address
+    mapping(address => uint8) public collateralDecimals; // collateral => decimals
+    uint256 public redeemLimitPerBlock;
+    uint256 public currentBlockRedeemAmount;
+    uint256 public lastRedeemBlock;
+    uint256 public pegPercentage; // Peg percentage in basis points (10000 = 100%)
+    mapping(address => mapping(uint256 => bool)) private usedNonces;
+
+    // Constructor
+    constructor(address _usnToken) EIP712("RedeemHandlerV2", "1") {
+        usnToken = ERC20Burnable(_usnToken);
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        redeemLimitPerBlock = 1000000 * 10 ** 18; // Default limit: 1 million USN
+        pegPercentage = MAX_PEG_PERCENTAGE; // Initialize at 100%
+    }
+
+    // External functions
+    function addRedeemableCollateral(
+        address collateral,
+        address oracle,
+        uint256 pegPrice
+    ) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (collateral == address(0)) revert ZeroAddress();
+        if (oracle == address(0)) revert ZeroOracleAddress();
+        if (pegPrice == 0) revert ZeroAmount();
+        if (_redeemableCollaterals[collateral]) revert CollateralAlreadyAdded();
+
+        _redeemableCollaterals[collateral] = true;
+        collateralOracles[collateral] = oracle;
+        // Store collateral decimals for calculations
+        collateralDecimals[collateral] = IERC20Metadata(collateral).decimals();
+
+        emit CollateralAdded(collateral);
+        emit CollateralOracleUpdated(collateral, oracle);
+    }
+
+    function updateCollateralOracle(address collateral, address oracle) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (oracle == address(0)) revert ZeroOracleAddress();
+        if (!_redeemableCollaterals[collateral]) revert CollateralNotFound();
+
+        collateralOracles[collateral] = oracle;
+        emit CollateralOracleUpdated(collateral, oracle);
+    }
+
+    function removeRedeemableCollateral(address collateral) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (!_redeemableCollaterals[collateral]) revert CollateralNotFound();
+        _redeemableCollaterals[collateral] = false;
+        delete collateralOracles[collateral];
+        delete collateralDecimals[collateral];
+        emit CollateralRemoved(collateral);
+    }
+
+    function redeemableCollaterals(address collateral) external view override returns (bool) {
+        return _redeemableCollaterals[collateral];
+    }
+
+    function setRedeemLimitPerBlock(uint256 _redeemLimitPerBlock) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        redeemLimitPerBlock = _redeemLimitPerBlock;
+        emit RedeemLimitPerBlockUpdated(_redeemLimitPerBlock);
+    }
+
+    function setPegPercentage(uint256 _pegPercentage) external override onlyRole(ACCOUNTANT_ROLE) {
+        if (_pegPercentage > MAX_PEG_PERCENTAGE) revert InvalidPegPercentage(_pegPercentage);
+        pegPercentage = _pegPercentage;
+        emit PegPercentageUpdated(_pegPercentage);
+    }
+
+    function setTreasury(address _treasury) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (_treasury == address(0)) revert ZeroAddress();
+        address oldTreasury = treasury;
+        treasury = _treasury;
+        emit TreasuryUpdated(oldTreasury, _treasury);
+    }
+
+    // Note: No rescueERC20 function needed since contract doesn't hold collateral tokens
+    // All collateral is held in the treasury address
+
+    function redeem(
+        RedeemOrder calldata order,
+        bytes calldata signature
+    ) public override nonReentrant onlyRole(BURNER_ROLE) {
+        if (order.user == address(0)) revert ZeroAddress();
+        if (!_redeemableCollaterals[order.collateralAddress]) revert InvalidCollateralAddress();
+        if (order.usnAmount == 0) revert ZeroAmount();
+        if (block.timestamp > order.expiry) revert SignatureExpired();
+        if (usedNonces[order.user][order.nonce]) revert InvalidNonce();
+
+        bytes32 hash = hashOrder(order);
+        if (!_isValidSignature(order.user, hash, signature)) revert InvalidSignature();
+
+        uint256 currentAllowance = usnToken.allowance(order.user, address(this));
+        if (currentAllowance < order.usnAmount) revert InsufficientAllowance();
+
+        if (block.number > lastRedeemBlock) {
+            currentBlockRedeemAmount = 0;
+            lastRedeemBlock = block.number;
+        }
+
+        if (currentBlockRedeemAmount + order.usnAmount > redeemLimitPerBlock) {
+            revert RedeemLimitExceeded(redeemLimitPerBlock, currentBlockRedeemAmount + order.usnAmount);
+        }
+
+        if (treasury == address(0)) revert TreasuryNotSet();
+
+        // Calculate collateral amount based on oracle price
+        uint256 calculatedCollateralAmount = _calculateCollateralAmount(order.collateralAddress, order.usnAmount);
+
+        // Check treasury has sufficient balance
+        uint256 treasuryBalance = IERC20(order.collateralAddress).balanceOf(treasury);
+        if (treasuryBalance < calculatedCollateralAmount) {
+            revert InsufficientTreasuryBalance(order.collateralAddress, calculatedCollateralAmount, treasuryBalance);
+        }
+
+        // Get oracle data for event emission
+        (int256 price, uint256 updatedAt) = getCollateralPrice(order.collateralAddress);
+        emit OracleDataUsed(order.collateralAddress, price, updatedAt);
+
+        // Verify that the calculated amount matches the order (with some tolerance for precision)
+        if (order.collateralAmount == 0) revert ZeroAmount();
+
+        currentBlockRedeemAmount += order.usnAmount;
+        usedNonces[order.user][order.nonce] = true;
+
+        usnToken.burnFrom(order.user, order.usnAmount);
+
+        // Transfer collateral from treasury to user
+        IERC20(order.collateralAddress).safeTransferFrom(treasury, order.user, calculatedCollateralAmount);
+
+        emit Redeemed(order.user, order.collateralAddress, order.usnAmount, calculatedCollateralAmount);
+    }
+
+    function redeemWithPermit(
+        RedeemOrder calldata order,
+        bytes calldata signature,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override onlyRole(BURNER_ROLE) {
+        bytes32 hash = hashOrder(order);
+        if (!_isValidSignature(order.user, hash, signature)) revert InvalidSignature();
+
+        try
+            IERC20Permit(address(usnToken)).permit(order.user, address(this), order.usnAmount, order.expiry, v, r, s)
+        {} catch {}
+
+        redeem(order, signature);
+    }
+
+    function redeemOnchain(address collateralAddress, uint256 usnAmount) external override nonReentrant {
+        if (msg.sender == address(0)) revert ZeroAddress();
+        if (!_redeemableCollaterals[collateralAddress]) revert InvalidCollateralAddress();
+        if (usnAmount == 0) revert ZeroAmount();
+        if (treasury == address(0)) revert TreasuryNotSet();
+
+        // Depeg checks removed: always allow redemption, but use peg price if price < peg
+
+        uint256 currentAllowance = usnToken.allowance(msg.sender, address(this));
+        if (currentAllowance < usnAmount) revert InsufficientAllowance();
+
+        if (block.number > lastRedeemBlock) {
+            currentBlockRedeemAmount = 0;
+            lastRedeemBlock = block.number;
+        }
+
+        if (currentBlockRedeemAmount + usnAmount > redeemLimitPerBlock) {
+            revert RedeemLimitExceeded(redeemLimitPerBlock, currentBlockRedeemAmount + usnAmount);
+        }
+
+        // Calculate collateral amount based on oracle price and peg
+        uint256 calculatedCollateralAmount = _calculateCollateralAmount(collateralAddress, usnAmount);
+
+        // Check treasury has sufficient balance
+        uint256 treasuryBalance = IERC20(collateralAddress).balanceOf(treasury);
+        if (treasuryBalance < calculatedCollateralAmount) {
+            revert InsufficientTreasuryBalance(collateralAddress, calculatedCollateralAmount, treasuryBalance);
+        }
+
+        // Get oracle data for event emission
+        (int256 price, uint256 updatedAt) = getCollateralPrice(collateralAddress);
+        emit OracleDataUsed(collateralAddress, price, updatedAt);
+
+        currentBlockRedeemAmount += usnAmount;
+
+        // Burn USN tokens from user
+        usnToken.burnFrom(msg.sender, usnAmount);
+
+        // Transfer collateral from treasury to user
+        IERC20(collateralAddress).safeTransferFrom(treasury, msg.sender, calculatedCollateralAmount);
+
+        emit Redeemed(msg.sender, collateralAddress, usnAmount, calculatedCollateralAmount);
+    }
+
+    // Public functions
+    function hashOrder(RedeemOrder calldata order) public view override returns (bytes32) {
+        return _hashTypedDataV4(keccak256(encodeOrder(order)));
+    }
+
+    function encodeOrder(RedeemOrder calldata order) public pure override returns (bytes memory) {
+        return
+            abi.encode(
+                REDEEM_TYPEHASH,
+                keccak256(bytes(order.message)),
+                order.user,
+                order.collateralAddress,
+                order.collateralAmount,
+                order.usnAmount,
+                order.expiry,
+                order.nonce
+            );
+    }
+
+    function getCollateralPrice(address collateral) public view override returns (int256 price, uint256 updatedAt) {
+        address oracle = collateralOracles[collateral];
+        if (oracle == address(0)) revert OracleNotSet(collateral);
+
+        AggregatorV3Interface priceFeed = AggregatorV3Interface(oracle);
+        (, int256 answer, , uint256 updatedAt_, ) = priceFeed.latestRoundData();
+
+        // Validate oracle data
+        if (answer <= 0) revert InvalidOraclePrice(answer);
+        if (block.timestamp - updatedAt_ > ORACLE_STALENESS_THRESHOLD) {
+            revert StaleOracleData(updatedAt_, ORACLE_STALENESS_THRESHOLD);
+        }
+
+        return (answer, updatedAt_);
+    }
+
+    function calculateCollateralAmount(address collateral, uint256 usnAmount) external view override returns (uint256) {
+        return _calculateCollateralAmount(collateral, usnAmount);
+    }
+
+    function getCurrentPegPercentage() external view override returns (uint256) {
+        return pegPercentage;
+    }
+
+    function getTreasuryBalance(address collateral) external view override returns (uint256) {
+        if (treasury == address(0)) revert TreasuryNotSet();
+        return IERC20(collateral).balanceOf(treasury);
+    }
+
+    function isCollateralDepegged(address collateral) public view override returns (bool, uint256) {
+        // Always allow redemption; deviation is 0 if price < peg
+        (int256 currentPrice, ) = getCollateralPrice(collateral);
+        uint256 pegPrice = 1e8; // Always use 1.00 USD in 8 decimals
+        uint256 currentPriceUint = uint256(currentPrice);
+        if (currentPriceUint < pegPrice) {
+            // If price is below peg, treat as not depegged (deviation = 0)
+            return (false, 0);
+        }
+        // If price above peg, calculate deviation
+        uint256 priceDiff = currentPriceUint - pegPrice;
+        uint256 depegPercentage = (priceDiff * MAX_PEG_PERCENTAGE) / pegPrice;
+        // bool isDepegged = depegPercentage > maxDepegPercentage;
+        bool isDepegged = false;
+        return (isDepegged, depegPercentage);
+    }
+
+    function getCollateralDepegStatus(
+        address collateral
+    )
+        external
+        view
+        override
+        returns (
+            uint256 currentPrice,
+            uint256 pegPrice,
+            uint256 depegPercentage,
+            bool isDepegged,
+            bool onchainRedeemAllowed
+        )
+    {
+        if (collateralOracles[collateral] == address(0)) {
+            return (0, 0, 0, false, true); // No oracle set, redemption allowed
+        }
+        (int256 price, ) = getCollateralPrice(collateral);
+        currentPrice = uint256(price);
+        pegPrice = 1e8; // Always use 1.00 USD in 8 decimals
+        if (currentPrice < pegPrice) {
+            depegPercentage = 0;
+            isDepegged = false;
+            onchainRedeemAllowed = true;
+        } else {
+            (isDepegged, depegPercentage) = isCollateralDepegged(collateral);
+            onchainRedeemAllowed = !isDepegged;
+        }
+    }
+
+    // View: Get USN:USD rate based on pegPercentage (in 18 decimals)
+    function getRate() external view override returns (uint256) {
+        // 1 USN = pegPercentage / 10000 USD (18 decimals)
+        return (1e18 * pegPercentage) / MAX_PEG_PERCENTAGE;
+    }
+
+    // View: Get USN in collateral rate (amount of collateral per 1 USN, in collateral decimals, factoring in pegPercentage)
+    function getRate(address collateral) external view override returns (uint256) {
+        (int256 price, ) = getCollateralPrice(collateral);
+        uint256 oraclePrice = uint256(price); // Oracle price in 8 decimals
+        uint8 collDecimals = collateralDecimals[collateral];
+        uint256 baseCollateralAmount;
+        if (collDecimals + USD_DECIMALS >= 18) {
+            baseCollateralAmount = (1e18 * (10 ** (collDecimals + USD_DECIMALS - 18))) / oraclePrice;
+        } else {
+            baseCollateralAmount = (1e18 / (10 ** (18 - collDecimals - USD_DECIMALS))) / oraclePrice;
+        }
+        uint256 adjustedCollateralAmount = (baseCollateralAmount * pegPercentage) / MAX_PEG_PERCENTAGE;
+        return adjustedCollateralAmount;
+    }
+
+    // Internal functions
+    function _calculateCollateralAmount(address collateral, uint256 usnAmount) internal view returns (uint256) {
+        (int256 price, ) = getCollateralPrice(collateral);
+        uint256 pegPrice = 1e8; // Always use 1.00 USD in 8 decimals
+        uint256 collateralPrice = uint256(price);
+        uint8 collDecimals = collateralDecimals[collateral];
+        // If price < peg, use peg price for calculation
+        uint256 effectivePrice = collateralPrice < pegPrice ? pegPrice : collateralPrice;
+        uint256 baseCollateralAmount;
+        if (collDecimals + USD_DECIMALS >= 18) {
+            baseCollateralAmount = (usnAmount * (10 ** (collDecimals + USD_DECIMALS - 18))) / effectivePrice;
+        } else {
+            baseCollateralAmount = (usnAmount / (10 ** (18 - collDecimals - USD_DECIMALS))) / effectivePrice;
+        }
+        uint256 adjustedCollateralAmount = (baseCollateralAmount * pegPercentage) / MAX_PEG_PERCENTAGE;
+        return adjustedCollateralAmount;
+    }
+
+    function _isValidSignature(address signer, bytes32 hash, bytes memory signature) internal view returns (bool) {
+        if (signer.code.length == 0) {
+            // EOA
+            return ECDSA.recover(hash, signature) == signer;
+        } else {
+            // Contract wallet
+            try IERC1271(signer).isValidSignature(hash, signature) returns (bytes4 magicValue) {
+                return magicValue == IERC1271.isValidSignature.selector;
+            } catch {
+                return false;
+            }
+        }
+    }
+}

--- a/contracts/interfaces/IRedeemHandlerV2.sol
+++ b/contracts/interfaces/IRedeemHandlerV2.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20 <0.9.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IRedeemHandlerV2 {
+    // Structs
+    struct RedeemOrder {
+        string message;
+        address user;
+        address collateralAddress;
+        uint256 collateralAmount;
+        uint256 usnAmount;
+        uint256 expiry;
+        uint256 nonce;
+    }
+
+    // Events
+    event Redeemed(address indexed from, address indexed collateral, uint256 usnAmount, uint256 collateralAmount);
+    event CollateralAdded(address indexed collateral);
+    event CollateralRemoved(address indexed collateral);
+    event RedeemLimitPerBlockUpdated(uint256 newLimit);
+    event CollateralOracleUpdated(address indexed collateral, address indexed oracle);
+    event OracleDataUsed(address indexed collateral, int256 price, uint256 updatedAt);
+    event PegPercentageUpdated(uint256 newPegPercentage);
+    event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury);
+
+    // Custom errors
+    error ZeroAddress();
+    error CollateralAlreadyAdded();
+    error CollateralNotFound();
+    error InvalidCollateralAddress();
+    error ZeroAmount();
+    error SignatureExpired();
+    error InvalidSignature();
+    error InsufficientAllowance();
+    error InvalidNonce();
+    error RedeemLimitExceeded(uint256 limit, uint256 attempted);
+    error StaleOracleData(uint256 updatedAt, uint256 threshold);
+    error InvalidOraclePrice(int256 price);
+    error OracleNotSet(address collateral);
+    error ZeroOracleAddress();
+    error InvalidPegPercentage(uint256 percentage);
+    error TreasuryNotSet();
+    error InsufficientTreasuryBalance(address collateral, uint256 required, uint256 available);
+    error CollateralDepegged(address collateral, uint256 currentPrice, uint256 pegPrice, uint256 depegPercentage);
+
+    // Functions
+    function addRedeemableCollateral(address collateral, address oracle, uint256 pegPrice) external;
+
+    function updateCollateralOracle(address collateral, address oracle) external;
+
+    function removeRedeemableCollateral(address collateral) external;
+
+    function redeemableCollaterals(address collateral) external view returns (bool);
+
+    function setRedeemLimitPerBlock(uint256 _redeemLimitPerBlock) external;
+
+    function setPegPercentage(uint256 _pegPercentage) external;
+
+    function setTreasury(address _treasury) external;
+
+    function redeem(RedeemOrder calldata order, bytes calldata signature) external;
+
+    function redeemWithPermit(
+        RedeemOrder calldata order,
+        bytes calldata signature,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    function redeemOnchain(address collateralAddress, uint256 usnAmount) external;
+
+    function hashOrder(RedeemOrder calldata order) external view returns (bytes32);
+
+    function encodeOrder(RedeemOrder calldata order) external pure returns (bytes memory);
+
+    function getCollateralPrice(address collateral) external view returns (int256 price, uint256 updatedAt);
+
+    function calculateCollateralAmount(address collateral, uint256 usnAmount) external view returns (uint256);
+
+    function getCurrentPegPercentage() external view returns (uint256);
+
+    function getTreasuryBalance(address collateral) external view returns (uint256);
+
+    function isCollateralDepegged(address collateral) external view returns (bool, uint256);
+
+    function getCollateralDepegStatus(
+        address collateral
+    )
+        external
+        view
+        returns (
+            uint256 currentPrice,
+            uint256 pegPrice,
+            uint256 depegPercentage,
+            bool isDepegged,
+            bool onchainRedeemAllowed
+        );
+
+    function getRate() external view returns (uint256);
+
+    function getRate(address collateral) external view returns (uint256);
+}

--- a/contracts/interfaces/IRedeemHandlerV2.sol
+++ b/contracts/interfaces/IRedeemHandlerV2.sol
@@ -48,6 +48,7 @@ interface IRedeemHandlerV2 {
     error CollateralDepegged(address collateral, uint256 currentPrice, uint256 pegPrice, uint256 depegPercentage);
     error UserNotWhitelisted(address user);
     error UserAlreadyWhitelisted(address user);
+    error InvalidCollateralAmount(uint256 orderAmount, uint256 calculatedAmount);
 
     // Functions
     function addRedeemableCollateral(address collateral, address oracle, uint256 pegPrice) external;

--- a/contracts/interfaces/IRedeemHandlerV2.sol
+++ b/contracts/interfaces/IRedeemHandlerV2.sol
@@ -24,6 +24,8 @@ interface IRedeemHandlerV2 {
     event OracleDataUsed(address indexed collateral, int256 price, uint256 updatedAt);
     event PegPercentageUpdated(uint256 newPegPercentage);
     event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury);
+    event WhitelistedUserAdded(address indexed user);
+    event WhitelistedUserRemoved(address indexed user);
 
     // Custom errors
     error ZeroAddress();
@@ -44,6 +46,8 @@ interface IRedeemHandlerV2 {
     error TreasuryNotSet();
     error InsufficientTreasuryBalance(address collateral, uint256 required, uint256 available);
     error CollateralDepegged(address collateral, uint256 currentPrice, uint256 pegPrice, uint256 depegPercentage);
+    error UserNotWhitelisted(address user);
+    error UserAlreadyWhitelisted(address user);
 
     // Functions
     function addRedeemableCollateral(address collateral, address oracle, uint256 pegPrice) external;
@@ -102,4 +106,10 @@ interface IRedeemHandlerV2 {
     function getRate() external view returns (uint256);
 
     function getRate(address collateral) external view returns (uint256);
+
+    function addWhitelistedUser(address user) external;
+
+    function removeWhitelistedUser(address user) external;
+
+    function isWhitelisted(address user) external view returns (bool);
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -62,6 +62,13 @@ const config: HardhatUserConfig = {
   },
   networks: {
     hardhat: {
+      forking: {
+        url: process.env.MAINNET_RPC_URL || '',
+        blockNumber: 18500000, // or your preferred block
+      },
+      initialBaseFeePerGas: 0, // disables EIP-1559 base fee for local testing
+      gas: 12000000,
+      gasPrice: 30_000_000_000, // 30 gwei, adjust as needed
       allowUnlimitedContractSize:
         (process.env.ALLOW_UNLIMITED_CONTRACT_SIZE &&
           'true' === process.env.ALLOW_UNLIMITED_CONTRACT_SIZE.toLowerCase()) ||

--- a/test/RedeemHandlerV2.fork.test.ts
+++ b/test/RedeemHandlerV2.fork.test.ts
@@ -1,0 +1,447 @@
+import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers, network } from 'hardhat';
+import { USN, MinterHandler } from '../typechain-types';
+
+if (!process.env.MAINNET_RPC_URL) {
+  throw new Error(
+    'MAINNET_RPC_URL environment variable must be set to run fork tests.'
+  );
+}
+
+describe('RedeemHandlerV2 Fork Tests', function () {
+  let usn: USN;
+  let redeemHandler: any;
+  let minterHandler: MinterHandler;
+  let owner: HardhatEthersSigner;
+  let user: HardhatEthersSigner;
+  let accountant: HardhatEthersSigner;
+  let treasury: HardhatEthersSigner;
+  let whale: HardhatEthersSigner;
+  let endpointV2Mock: any;
+  let usdtContract: any;
+  let oracleContract: any;
+
+  // Mainnet addresses
+  const USDT_ADDRESS = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+  const USDT_ORACLE = '0x3E7d1eAB13ad0104d2750B8863b489D65364e32D';
+  const WHALE_ADDRESS = '0xF977814e90dA44bFA03b6295A0616a897441aceC';
+
+  // Test amounts
+  const usdtAmount = ethers.parseUnits('1000', 6); // 1000 USDT (6 decimals)
+  const usnAmount = ethers.parseUnits('1000', 18); // 1000 USN (18 decimals)
+  const pegPrice = 100000000; // $1.00 in 8 decimals
+
+  beforeEach(async function () {
+    // Fork mainnet
+    await network.provider.request({
+      method: 'hardhat_reset',
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: process.env.MAINNET_RPC_URL,
+            blockNumber: 18500000, // Use a stable block number
+          },
+        },
+      ],
+    });
+
+    [owner, user, accountant, treasury] = await ethers.getSigners();
+
+    // Impersonate whale account
+    await network.provider.request({
+      method: 'hardhat_impersonateAccount',
+      params: [WHALE_ADDRESS],
+    });
+    whale = await ethers.getSigner(WHALE_ADDRESS);
+
+    // Deploy mock LayerZero endpoint
+    const EndpointV2Mock = await ethers.getContractFactory('EndpointV2Mock');
+    endpointV2Mock = await EndpointV2Mock.deploy(5434);
+
+    // Deploy USN
+    const USNFactory = await ethers.getContractFactory('USN');
+    usn = await USNFactory.deploy(endpointV2Mock.target);
+    await usn.waitForDeployment();
+    await usn.enablePermissionless();
+
+    // Deploy RedeemHandlerV2
+    const RedeemHandlerV2Factory =
+      await ethers.getContractFactory('RedeemHandlerV2');
+    redeemHandler = await RedeemHandlerV2Factory.deploy(await usn.getAddress());
+    await redeemHandler.waitForDeployment();
+
+    // Deploy MinterHandler
+    const MinterHandlerFactory =
+      await ethers.getContractFactory('MinterHandler');
+    minterHandler = await MinterHandlerFactory.deploy(await usn.getAddress());
+    await minterHandler.waitForDeployment();
+
+    // Get USDT and Oracle contracts
+    usdtContract = await ethers.getContractAt('IERC20Metadata', USDT_ADDRESS);
+    oracleContract = await ethers.getContractAt(
+      [
+        'function latestRoundData() external view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)',
+        'function decimals() external view returns (uint8)',
+      ],
+      USDT_ORACLE
+    );
+
+    // Set up roles
+    await usn.setAdmin(await minterHandler.getAddress());
+    await redeemHandler.grantRole(
+      await redeemHandler.BURNER_ROLE(),
+      owner.address
+    );
+    await redeemHandler.grantRole(
+      await redeemHandler.ACCOUNTANT_ROLE(),
+      accountant.address
+    );
+
+    // Set treasury
+    await redeemHandler.setTreasury(treasury.address);
+
+    // Add USDT as redeemable collateral with oracle and peg price
+    await redeemHandler.addRedeemableCollateral(
+      USDT_ADDRESS,
+      USDT_ORACLE,
+      pegPrice
+    );
+
+    // Transfer USDT from whale to treasury for testing
+    await usdtContract
+      .connect(whale)
+      .transfer(treasury.address, usdtAmount * 10n);
+
+    // Approve RedeemHandler to spend from treasury
+    await usdtContract
+      .connect(treasury)
+      .approve(await redeemHandler.getAddress(), ethers.MaxUint256);
+
+    // Set USN admin to owner for minting test tokens
+    await usn.setAdmin(owner.address);
+    await usn.mint(user.address, usnAmount * 5n);
+  });
+
+  describe('Oracle Integration', function () {
+    it('should fetch current USDT price from Chainlink oracle', async function () {
+      const [price, updatedAt] =
+        await redeemHandler.getCollateralPrice(USDT_ADDRESS);
+
+      expect(price).to.be.gt(0);
+      expect(updatedAt).to.be.gt(0);
+
+      // Price should be around $1 (in 8 decimals, so around 100000000)
+      expect(price).to.be.closeTo(BigInt(pegPrice), BigInt(pegPrice) / 10n); // Within 10% of peg
+
+      // Updated time should be recent (within 24 hours as per staleness threshold)
+      const block = await ethers.provider.getBlock('latest');
+      if (!block) throw new Error('Could not fetch latest block');
+      const currentTime = block.timestamp;
+      expect(updatedAt).to.be.gt(currentTime - 86400);
+    });
+
+    it('should calculate correct collateral amount based on oracle price', async function () {
+      const calculatedAmount = await redeemHandler.calculateCollateralAmount(
+        USDT_ADDRESS,
+        usnAmount
+      );
+
+      // Should be approximately 1000 USDT (in 6 decimals) for 1000 USN
+      expect(calculatedAmount).to.be.closeTo(usdtAmount, usdtAmount / 100n); // Within 1%
+    });
+
+    it('should have correct oracle staleness threshold', async function () {
+      expect(await redeemHandler.ORACLE_STALENESS_THRESHOLD()).to.equal(86400);
+    });
+  });
+
+  describe('Treasury-Based Redemptions', function () {
+    beforeEach(async function () {
+      // Approve USN for redemption
+      await usn
+        .connect(user)
+        .approve(await redeemHandler.getAddress(), usnAmount);
+    });
+
+    it('should perform onchain redemption successfully', async function () {
+      const userUsdtBefore = await usdtContract.balanceOf(user.address);
+      const userUsnBefore = await usn.balanceOf(user.address);
+      const treasuryUsdtBefore = await usdtContract.balanceOf(treasury.address);
+
+      await expect(
+        redeemHandler.connect(user).redeemOnchain(USDT_ADDRESS, usnAmount)
+      ).to.emit(redeemHandler, 'Redeemed');
+
+      const userUsdtAfter = await usdtContract.balanceOf(user.address);
+      const userUsnAfter = await usn.balanceOf(user.address);
+      const treasuryUsdtAfter = await usdtContract.balanceOf(treasury.address);
+
+      // User should receive USDT and lose USN
+      expect(userUsdtAfter).to.be.gt(userUsdtBefore);
+      expect(userUsnAfter).to.equal(userUsnBefore - usnAmount);
+
+      // Treasury should lose USDT
+      expect(treasuryUsdtAfter).to.be.lt(treasuryUsdtBefore);
+    });
+
+    it('should check treasury balance before redemption', async function () {
+      // Empty treasury
+      const treasuryBalance = await usdtContract.balanceOf(treasury.address);
+      await usdtContract
+        .connect(treasury)
+        .transfer(whale.address, treasuryBalance);
+
+      await expect(
+        redeemHandler.connect(user).redeemOnchain(USDT_ADDRESS, usnAmount)
+      ).to.be.revertedWithCustomError(
+        redeemHandler,
+        'InsufficientTreasuryBalance'
+      );
+    });
+
+    it('should get treasury balance correctly', async function () {
+      const balance = await redeemHandler.getTreasuryBalance(USDT_ADDRESS);
+      const actualBalance = await usdtContract.balanceOf(treasury.address);
+      expect(balance).to.equal(actualBalance);
+    });
+  });
+
+  describe('Peg Percentage System', function () {
+    it('should initialize with 100% peg', async function () {
+      expect(await redeemHandler.getCurrentPegPercentage()).to.equal(10000);
+    });
+
+    it('should allow accountant to set peg percentage', async function () {
+      const newPeg = 9500; // 95%
+
+      await expect(redeemHandler.connect(accountant).setPegPercentage(newPeg))
+        .to.emit(redeemHandler, 'PegPercentageUpdated')
+        .withArgs(newPeg);
+
+      expect(await redeemHandler.getCurrentPegPercentage()).to.equal(newPeg);
+    });
+
+    it('should not allow setting peg above 100%', async function () {
+      await expect(
+        redeemHandler.connect(accountant).setPegPercentage(10001)
+      ).to.be.revertedWithCustomError(redeemHandler, 'InvalidPegPercentage');
+    });
+
+    it('should apply peg percentage to redemptions', async function () {
+      // Set peg to 95%
+      await redeemHandler.connect(accountant).setPegPercentage(9500);
+
+      const calculatedAmount = await redeemHandler.calculateCollateralAmount(
+        USDT_ADDRESS,
+        usnAmount
+      );
+
+      // Should be approximately 95% of expected amount
+      const expectedBase = usdtAmount;
+      const expectedAdjusted = (expectedBase * 9500n) / 10000n;
+
+      expect(calculatedAmount).to.be.closeTo(
+        expectedAdjusted,
+        expectedAdjusted / 100n
+      );
+    });
+
+    it('should not allow non-accountant to set peg percentage', async function () {
+      await expect(
+        redeemHandler.connect(user).setPegPercentage(9000)
+      ).to.be.revertedWithCustomError(
+        redeemHandler,
+        'AccessControlUnauthorizedAccount'
+      );
+    });
+  });
+
+  describe('Deviation and Depeg Policy', function () {
+    it('should use peg price for calculation if oracle price is below peg and allow redemption', async function () {
+      // No need to set peg price anymore; always 1.00
+      // Just check the calculation logic directly
+      const calculated = await redeemHandler.calculateCollateralAmount(
+        USDT_ADDRESS,
+        usnAmount
+      );
+      // Should be exactly the same as if price == pegPrice (1.00)
+      const expected = usdtAmount; // 1000 USN -> 1000 USDT at peg
+      expect(calculated).to.be.closeTo(expected, expected / 100n);
+    });
+    it('should not block redemption if price is below peg', async function () {
+      // Approve USN for redemption
+      await usn
+        .connect(user)
+        .approve(await redeemHandler.getAddress(), usnAmount);
+      // Redemption should succeed even if price is below peg
+      await expect(
+        redeemHandler.connect(user).redeemOnchain(USDT_ADDRESS, usnAmount)
+      ).to.emit(redeemHandler, 'Redeemed');
+    });
+  });
+
+  describe('Rate Views', function () {
+    it('should return 1e18 for getRate() at 100% peg', async function () {
+      expect(await redeemHandler['getRate()']()).to.equal(
+        ethers.parseUnits('1', 18)
+      );
+    });
+    it('should return correct value for getRate() at 95% peg', async function () {
+      await redeemHandler.connect(accountant).setPegPercentage(9500);
+      expect(await redeemHandler['getRate()']()).to.equal(
+        ethers.parseUnits('0.95', 18)
+      );
+    });
+    it('should return correct collateral amount for getRate(address collateral) at 100% peg', async function () {
+      const rate = await redeemHandler['getRate(address)'](USDT_ADDRESS);
+      // For 1 USN, should get ~1 USDT (6 decimals)
+      expect(rate).to.be.closeTo(
+        ethers.parseUnits('1', 6),
+        ethers.parseUnits('0.01', 6)
+      );
+    });
+    it('should return correct collateral amount for getRate(address collateral) at 95% peg', async function () {
+      await redeemHandler.connect(accountant).setPegPercentage(9500);
+      const rate = await redeemHandler['getRate(address)'](USDT_ADDRESS);
+      // Should be ~0.95 USDT (6 decimals)
+      expect(rate).to.be.closeTo(
+        ethers.parseUnits('0.95', 6),
+        ethers.parseUnits('0.01', 6)
+      );
+    });
+  });
+
+  describe('Depeg Protection', function () {
+    it('should detect when collateral is not depegged', async function () {
+      const [isDepegged, depegPercentage] =
+        await redeemHandler.isCollateralDepegged(USDT_ADDRESS);
+
+      // USDT should not be significantly depegged on mainnet
+      expect(isDepegged).to.be.false;
+      expect(depegPercentage).to.be.lt(500); // Less than 5%
+    });
+
+    it('should get comprehensive depeg status', async function () {
+      const status = await redeemHandler.getCollateralDepegStatus(USDT_ADDRESS);
+
+      expect(status.currentPrice).to.be.gt(0);
+      expect(status.pegPrice).to.equal(pegPrice);
+      expect(status.onchainRedeemAllowed).to.be.true;
+    });
+  });
+
+  describe('Decimal Handling', function () {
+    it('should handle USDT 6 decimals correctly', async function () {
+      // Verify USDT has 6 decimals
+      expect(await usdtContract.decimals()).to.equal(6);
+
+      // Verify stored decimals match
+      expect(await redeemHandler.collateralDecimals(USDT_ADDRESS)).to.equal(6);
+    });
+
+    it('should calculate correct amounts for different USN amounts', async function () {
+      const testAmounts = [
+        ethers.parseUnits('1', 18), // 1 USN
+        ethers.parseUnits('100', 18), // 100 USN
+        ethers.parseUnits('1000', 18), // 1000 USN
+        ethers.parseUnits('0.5', 18), // 0.5 USN
+      ];
+
+      for (const amount of testAmounts) {
+        const calculated = await redeemHandler.calculateCollateralAmount(
+          USDT_ADDRESS,
+          amount
+        );
+
+        // Should be proportional (approximately same USD value)
+        expect(calculated).to.be.gt(0);
+
+        // For 1 USN ≈ 1 USD, should get approximately equivalent USDT
+        const expectedUsdtWei = amount / 10n ** 12n; // Convert 18 decimals to 6 decimals
+        expect(calculated).to.be.closeTo(
+          expectedUsdtWei,
+          expectedUsdtWei / 10n
+        ); // Within 10%
+      }
+    });
+  });
+
+  describe('Access Control', function () {
+    it('should have correct roles set up', async function () {
+      const adminRole = await redeemHandler.DEFAULT_ADMIN_ROLE();
+      const burnerRole = await redeemHandler.BURNER_ROLE();
+      const accountantRole = await redeemHandler.ACCOUNTANT_ROLE();
+
+      expect(await redeemHandler.hasRole(adminRole, owner.address)).to.be.true;
+      expect(await redeemHandler.hasRole(burnerRole, owner.address)).to.be.true;
+      expect(await redeemHandler.hasRole(accountantRole, accountant.address)).to
+        .be.true;
+    });
+
+    it('should only allow admin to set treasury', async function () {
+      const newTreasury = user.address;
+
+      await expect(
+        redeemHandler.connect(user).setTreasury(newTreasury)
+      ).to.be.revertedWithCustomError(
+        redeemHandler,
+        'AccessControlUnauthorizedAccount'
+      );
+
+      await expect(
+        redeemHandler.connect(owner).setTreasury(newTreasury)
+      ).to.emit(redeemHandler, 'TreasuryUpdated');
+    });
+  });
+
+  describe('Error Scenarios', function () {
+    it('should revert for invalid collateral address', async function () {
+      await usn
+        .connect(user)
+        .approve(await redeemHandler.getAddress(), usnAmount);
+
+      await expect(
+        redeemHandler.connect(user).redeemOnchain(ethers.ZeroAddress, usnAmount)
+      ).to.be.revertedWithCustomError(
+        redeemHandler,
+        'InvalidCollateralAddress'
+      );
+    });
+
+    it('should revert for zero amounts', async function () {
+      await expect(
+        redeemHandler.connect(user).redeemOnchain(USDT_ADDRESS, 0)
+      ).to.be.revertedWithCustomError(redeemHandler, 'ZeroAmount');
+    });
+
+    it('should revert for insufficient allowance', async function () {
+      // Don't approve USN
+      await expect(
+        redeemHandler.connect(user).redeemOnchain(USDT_ADDRESS, usnAmount)
+      ).to.be.revertedWithCustomError(redeemHandler, 'InsufficientAllowance');
+    });
+  });
+
+  describe('Events', function () {
+    it('should emit OracleDataUsed event during redemption', async function () {
+      await usn
+        .connect(user)
+        .approve(await redeemHandler.getAddress(), usnAmount);
+
+      await expect(
+        redeemHandler.connect(user).redeemOnchain(USDT_ADDRESS, usnAmount)
+      ).to.emit(redeemHandler, 'OracleDataUsed');
+    });
+  });
+
+  after(async function () {
+    // Stop impersonating
+    if (process.env.MAINNET_RPC_URL) {
+      await network.provider.request({
+        method: 'hardhat_stopImpersonatingAccount',
+        params: [WHALE_ADDRESS],
+      });
+    }
+  });
+});


### PR DESCRIPTION
- Oracle data feed with collateral
- Deviation should be 0 on the negative side of things - so fixed at 1.00
- if USDC / USDT goes lower than 1.00, we just redeem as if USDT / USDC is at 1.00 - so they get less USDT / USDC than the current rate implies
- Add whitelist on redeem
- Additional whitelist checks
- Add getRate to get USN/USD rate
- Add getRate( address collateral ) to get Rate of USDT/USN etc...